### PR TITLE
Add icons to entries

### DIFF
--- a/HaveIBeenPwned/BreachedEntriesDialog.Designer.cs
+++ b/HaveIBeenPwned/BreachedEntriesDialog.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             System.Windows.Forms.ColumnHeader titleHeader;
-            this.breachedEntryList = new System.Windows.Forms.ListView();
+            this.breachedEntryList = new KeePass.UI.CustomListViewEx();
             this.usernameHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.urlHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.lastModifiedHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -134,7 +134,7 @@
 
         #endregion
 
-        private System.Windows.Forms.ListView breachedEntryList;
+        private KeePass.UI.CustomListViewEx breachedEntryList;
         private System.Windows.Forms.ColumnHeader usernameHeader;
         private System.Windows.Forms.ColumnHeader urlHeader;
         private System.Windows.Forms.ColumnHeader lastModifiedHeader;

--- a/HaveIBeenPwned/BreachedEntriesDialog.cs
+++ b/HaveIBeenPwned/BreachedEntriesDialog.cs
@@ -23,6 +23,7 @@ namespace HaveIBeenPwned
         {
             breachedEntryList.Items.Clear();
             breachedEntryList.Groups.Clear();
+            breachedEntryList.SmallImageList = new ImageList();
             var groupNames = breaches.Select(b => b.Entry.ParentGroup.GetFullPath(" - ", false)).Distinct();
             foreach(var group in groupNames)
             {
@@ -31,6 +32,7 @@ namespace HaveIBeenPwned
             breachedEntryList.ShowGroups = true;
             foreach (var breach in breaches)
             {
+                breachedEntryList.SmallImageList.Images.Add(breach.Entry.GetIcon(pluginHost));
                 var newItem = new ListViewItem(new[]
                 {
                     breach.Entry.Strings.ReadSafe(PwDefs.TitleField),
@@ -41,7 +43,8 @@ namespace HaveIBeenPwned
                     breach.BreachDate.ToShortDateString()
                 })
                 {
-                    Tag = breach.Entry
+                    Tag = breach.Entry,
+                    ImageIndex = breachedEntryList.SmallImageList.Images.Count - 1
                 };
 
                 foreach(ListViewGroup group in breachedEntryList.Groups)

--- a/HaveIBeenPwned/PwEntryExtensions.cs
+++ b/HaveIBeenPwned/PwEntryExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using KeePass.Plugins;
 using KeePassLib;
 using System;
+using System.Drawing;
 using System.Linq;
 
 namespace HaveIBeenPwned
@@ -54,6 +55,25 @@ namespace HaveIBeenPwned
                 return domain;
             }
             catch (UriFormatException) { return string.Empty; }
+        }
+
+        public static Image GetIcon(this PwEntry entry, IPluginHost pluginHost)
+        {
+            var entryIcon = entry.IconId;
+            var customIcon = entry.CustomIconUuid;
+
+            if (!customIcon.Equals(PwUuid.Zero))
+            {
+                int w = KeePass.UI.DpiUtil.ScaleIntX(16);
+                int h = KeePass.UI.DpiUtil.ScaleIntY(16);
+
+                var imgCustom = pluginHost.Database.GetCustomIcon(customIcon, w, h);
+                return (imgCustom ?? pluginHost.MainWindow.ClientIcons.Images[(int)entryIcon]);
+            }
+            else
+            {
+                return pluginHost.MainWindow.ClientIcons.Images[(int)entryIcon];
+            }
         }
     }
 }


### PR DESCRIPTION
First pass. Not memory efficient as multiple entries with the same icon will produce duplicate entries in the image list. This is probably not a problem as the breached entry list is likely to be small(ish) or at least the entries will have unique custom icons anyway.