### PR TITLE
cache results for password's check

### DIFF
--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedPassword/HaveIBeenPwnedPasswordChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedPassword/HaveIBeenPwnedPasswordChecker.cs
@@ -66,18 +66,29 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedPassword
             List<HaveIBeenPwnedPasswordEntry> allBreaches = new List<HaveIBeenPwnedPasswordEntry>();
             int counter = 0;
             SHA1 sha = new SHA1CryptoServiceProvider();
-            
+
+            Dictionary<string, bool> cache = new Dictionary<string, bool>();
+
             foreach (var entry in entries)
             {
                 counter++;
                 progressIndicator.Report(new ProgressItem((uint)((double)counter / entries.Count() * 100), string.Format("Checking \"{0}\" for breaches", entry.Strings.ReadSafe(PwDefs.TitleField))));
                 if(entry.Strings.Get(PwDefs.PasswordField) == null || string.IsNullOrWhiteSpace(entry.Strings.ReadSafe(PwDefs.PasswordField)) || entry.Strings.ReadSafe(PwDefs.PasswordField).StartsWith("{REF:")) continue;
                 var passwordHash = string.Join("", sha.ComputeHash(entry.Strings.Get(PwDefs.PasswordField).ReadUtf8()).Select(x => x.ToString("x2"))).ToUpperInvariant();
+                if (cache.ContainsKey(passwordHash))
+                {
+                    if (cache[passwordHash])
+                    {
+                        allBreaches.Add(new HaveIBeenPwnedPasswordEntry(entry.Strings.ReadSafe(PwDefs.UserNameField), entry.GetUrlDomain(), entry));
+                    }
+                    continue;
+                }
                 var prefix = passwordHash.Substring(0, 5);
                 using (var response = await client.GetAsync(string.Format(API_URL, prefix)))
                 {
                     if (response.StatusCode == System.Net.HttpStatusCode.OK)
                     {
+                        cache[passwordHash] = false;
                         var stream = await response.Content.ReadAsStreamAsync();
                         using (var reader = new StreamReader(stream))
                         {
@@ -90,6 +101,7 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedPassword
                                 if (prefix + suffix == passwordHash)
                                 {
                                     allBreaches.Add(new HaveIBeenPwnedPasswordEntry(entry.Strings.ReadSafe(PwDefs.UserNameField), entry.GetUrlDomain(), entry));
+                                    cache[passwordHash] = true;
                                 }
                             }
                         }


### PR DESCRIPTION
Saving results for founded and not founded hashes.
Allow reduce requests and increase check speed with duplicated passwords in several entries.