### PR TITLE
allow break usernames check on error

### DIFF
--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedUsername/HaveIBeenPwnedUsernameChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedUsername/HaveIBeenPwnedUsernameChecker.cs
@@ -92,7 +92,12 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedUsername
                 }
                 else if (response.StatusCode != System.Net.HttpStatusCode.NotFound)
                 {
-                    MessageBox.Show(string.Format("Unable to check haveibeenpwned.com (returned Status: {0})", response.StatusCode), Resources.MessageTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    DialogResult dialogButton = MessageBox.Show(string.Format("Unable to check haveibeenpwned.com (returned Status: {0})", response.StatusCode), 
+                                                                Resources.MessageTitle, MessageBoxButtons.OKCancel, MessageBoxIcon.Error);
+                    if (dialogButton == DialogResult.Cancel)
+                    {
+                        break;
+                    }
                 }
                 if (breaches != null)
                 {


### PR DESCRIPTION
Added "Cancel" button to error dialog during username's check.
Allow user to stop entire check if server started returning errors on each entries (like in case of #56 )