### PR TITLE
Non-blocking window with results

### DIFF
--- a/HaveIBeenPwned/HaveIBeenPwnedExt.cs
+++ b/HaveIBeenPwned/HaveIBeenPwnedExt.cs
@@ -190,7 +190,7 @@ namespace HaveIBeenPwned
                 {
                     var breachedEntriesDialog = new BreachedEntriesDialog(pluginHost);
                     breachedEntriesDialog.AddBreaches(result);
-                    breachedEntriesDialog.ShowDialog();
+                    breachedEntriesDialog.Show();
                 }
             }
 

--- a/HaveIBeenPwned/UI/BreachedEntriesDialog.Designer.cs
+++ b/HaveIBeenPwned/UI/BreachedEntriesDialog.Designer.cs
@@ -103,6 +103,7 @@
             this.closeButton.TabIndex = 1;
             this.closeButton.Text = "Close";
             this.closeButton.UseVisualStyleBackColor = true;
+            this.closeButton.Click += new System.EventHandler(this.closeButton_Click);
             // 
             // label1
             // 

--- a/HaveIBeenPwned/UI/BreachedEntriesDialog.cs
+++ b/HaveIBeenPwned/UI/BreachedEntriesDialog.cs
@@ -107,5 +107,10 @@ namespace HaveIBeenPwned.UI
                 }
             }
         }
+
+        private void closeButton_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
     }
 }


### PR DESCRIPTION
Allow work with main window while dialog with results of check still opened.
Fix for #57 