### PR TITLE
Feature/optimisations

### DIFF
--- a/HaveIBeenPwned/BreachCheckers/CloudbleedSite/CloudbleedSiteChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/CloudbleedSite/CloudbleedSiteChecker.cs
@@ -33,11 +33,11 @@ namespace HaveIBeenPwned.BreachCheckers.CloudbleedSite
         {
             progressIndicator.Report(new ProgressItem(0, "Getting Cloudbleed breach list..."));
             var breaches = await GetBreaches(progressIndicator);
-            var entries = group.GetEntries(true).Where(e => (!ignoreDeleted || !e.IsDeleted(pluginHost)) && (!ignoreExpired || !e.Expires));
+            var entries = group.GetEntries(true).Where(e => (!ignoreDeleted || !e.IsDeleted(pluginHost)) && (!ignoreExpired || !e.Expires)).ToArray();
             var breachedEntries = new List<BreachedEntry>();
 
             uint counter = 0;
-            var entryCount = entries.Count();
+            var entryCount = entries.Length;
             await Task.Run(() =>
             {
                 foreach (var entry in entries)

--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedSite/HaveIBeenPwnedSiteChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedSite/HaveIBeenPwnedSiteChecker.cs
@@ -33,11 +33,11 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedSite
         {
             progressIndicator.Report(new ProgressItem(0, "Getting HaveIBeenPwned breach list..."));
             var breaches = await GetBreaches(progressIndicator);
-            var entries = group.GetEntries(true).Where(e => (!ignoreDeleted || !e.IsDeleted(pluginHost)) && (!ignoreExpired || !e.Expires));
+            var entries = group.GetEntries(true).Where(e => (!ignoreDeleted || !e.IsDeleted(pluginHost)) && (!ignoreExpired || !e.Expires)).ToArray();
             var breachedEntries = new List<BreachedEntry>();
 
             uint counter = 0;
-            var entryCount = entries.Count();
+            var entryCount = entries.Length;
             await Task.Run(() =>
             {
                 foreach (var entry in entries)

--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedUsername/HaveIBeenPwnedUsernameChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedUsername/HaveIBeenPwnedUsernameChecker.cs
@@ -42,7 +42,9 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedUsername
             {
                 foreach (var breach in breaches)
                 {
-                    var pwEntry = entries.FirstOrDefault(e => e.GetUrlDomain() == breach.Domain);
+                    var pwEntry =
+                        string.IsNullOrWhiteSpace(breach.Domain) ? null :
+                        entries.FirstOrDefault(e => e.GetUrlDomain() == breach.Domain && breach.Username == e.Strings.ReadSafe(PwDefs.UserNameField).Trim().ToLower());
                     if (pwEntry != null)
                     {
                         var lastModified = pwEntry.GetPasswordLastModified();

--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedUsername/HaveIBeenPwnedUsernameChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedUsername/HaveIBeenPwnedUsernameChecker.cs
@@ -33,8 +33,8 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedUsername
         public async override Task<List<BreachedEntry>> CheckGroup(PwGroup group, bool expireEntries, bool oldEntriesOnly, bool ignoreDeleted, bool ignoreExpired, IProgress<ProgressItem> progressIndicator, Func<bool> canContinue)
         {
             progressIndicator.Report(new ProgressItem(0, "Getting HaveIBeenPwned breach list..."));
-            var usernames = entries.Select(e => e.Strings.ReadSafe(PwDefs.UserNameField)).Distinct();
             var entries = group.GetEntries(true).Where(e => (!ignoreDeleted || !e.IsDeleted(pluginHost)) && (!ignoreExpired || !e.Expires)).ToArray();
+            var usernames = entries.Select(e => e.Strings.ReadSafe(PwDefs.UserNameField).Trim().ToLower()).Distinct();
             var breaches = await GetBreaches(progressIndicator, usernames, canContinue);
             var breachedEntries = new List<BreachedEntry>();
 

--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedUsername/HaveIBeenPwnedUsernameChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedUsername/HaveIBeenPwnedUsernameChecker.cs
@@ -33,8 +33,8 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedUsername
         public async override Task<List<BreachedEntry>> CheckGroup(PwGroup group, bool expireEntries, bool oldEntriesOnly, bool ignoreDeleted, bool ignoreExpired, IProgress<ProgressItem> progressIndicator, Func<bool> canContinue)
         {
             progressIndicator.Report(new ProgressItem(0, "Getting HaveIBeenPwned breach list..."));
-            var entries = group.GetEntries(true).Where(e => (!ignoreDeleted || !e.IsDeleted(pluginHost)) && (!ignoreExpired || !e.Expires));
             var usernames = entries.Select(e => e.Strings.ReadSafe(PwDefs.UserNameField)).Distinct();
+            var entries = group.GetEntries(true).Where(e => (!ignoreDeleted || !e.IsDeleted(pluginHost)) && (!ignoreExpired || !e.Expires)).ToArray();
             var breaches = await GetBreaches(progressIndicator, usernames, canContinue);
             var breachedEntries = new List<BreachedEntry>();
 


### PR DESCRIPTION
Made a few optimisation to how the checkers, particularly the username checker
- Trims and lowers the username (to match the server side)
- Ensure matched entry has the same username, not just the same domain
- Can now properly filter out breach who's dates are older than the oldest password change of that username
- Minor enumerable optimisation.