### PR TITLE
Support for individual breach ignores

### DIFF
--- a/HaveIBeenPwned/BreachCheckers/BreachedEntry.cs
+++ b/HaveIBeenPwned/BreachCheckers/BreachedEntry.cs
@@ -1,11 +1,15 @@
-﻿using KeePassLib;
+﻿using KeePass.Plugins;
+using KeePassLib;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace HaveIBeenPwned.BreachCheckers
 {
     public class BreachedEntry
     {
         private IBreach breach;
+        private IPluginHost pluginHost;
 
         public PwEntry Entry { get; private set; }
 
@@ -58,10 +62,114 @@ namespace HaveIBeenPwned.BreachCheckers
             }
         }
 
-        public BreachedEntry(PwEntry entry, IBreach breach)
+        public BreachedEntry(IPluginHost pluginHost, PwEntry entry, IBreach breach)
         {
             Entry = entry;
             this.breach = breach;
+            this.pluginHost = pluginHost;
+        }
+
+        public bool IsIgnored
+        {
+            get
+            {
+                if (Entry == null)
+                {
+                    // At the moment the only way a breach can have no entry is if it's a breached username
+                    return GetIgnoredBreachForUserName().Contains(BreachName);
+                }
+
+                // Otherwise, see if this particular breach is ignored for this entry
+                return GetIngoredBreachesForThisEntry().Contains(BreachName);
+            }
+        }
+
+        private string[] GetIngoredBreachesForThisEntry()
+        {
+            if (Entry == null)
+            {
+                return new string[] { };
+            }
+
+            var items = Entry.CustomData.Get<string[]>(Resources.FieldNameIgnoredBreachs);
+            return items == null ? new string[] { } : items;
+        }
+
+        private void SetIngoredBreachForThisEntry(string[] value)
+        {
+            if (Entry == null)
+            {
+                throw new NotSupportedException();
+            }
+
+            var arrayValue = value.OrderBy(x => x).ToArray();
+            var modified = Entry.CustomData.Set(Resources.FieldNameIgnoredBreachs, arrayValue.Length > 0 ? arrayValue : null);
+            if (modified)
+            {
+                pluginHost.MarkAsModified();
+            }
+        }
+
+        public void IgnoreForThisEntry()
+        {
+            var items = GetIngoredBreachesForThisEntry().ToList();
+            items.Add(BreachName);
+            SetIngoredBreachForThisEntry(items.Distinct().ToArray());
+        }
+
+        public void StopIgnoringBreachForThisEntry()
+        {
+            var items = GetIngoredBreachesForThisEntry().Where(x => x != BreachName).ToArray();
+            SetIngoredBreachForThisEntry(items);
+        }
+
+        public Dictionary<string, string[]> GetUserIgnoreList()
+        {
+            var items = pluginHost.Database.RootGroup.CustomData.Get<Dictionary<string, string[]>>(Resources.FieldNameIgnoredBreachs);
+            return items == null ? new Dictionary<string, string[]>() { } : items;
+        }
+
+        private void SetGloballyIgnoredBreachesByUser(string[] breaches)
+        {
+
+            var currentIgnores = GetUserIgnoreList();
+            if (breaches != null && breaches.Length > 0)
+            {
+                currentIgnores[BreachUsername] = breaches;
+            }
+            else
+            {
+                currentIgnores.Remove(BreachUsername);
+            }
+
+            var entry = pluginHost.Database.RootGroup;
+            var modified = entry.CustomData.Set(Resources.FieldNameIgnoredBreachs, currentIgnores.Count > 0 ? currentIgnores : null);
+            if (modified)
+            {
+                pluginHost.MarkAsModified();
+            }
+        }
+
+        public string[] GetIgnoredBreachForUserName()
+        {
+            string[] value;
+            if (!GetUserIgnoreList().TryGetValue(BreachUsername, out value))
+            {
+                value = new string[] { };
+            }
+
+            return value;
+        }
+
+        public void AddBreachToUserIgnoreList()
+        {
+            var value = GetIgnoredBreachForUserName().Concat(new[] { BreachName }).OrderBy(x => x).ToArray();
+            SetGloballyIgnoredBreachesByUser(value);
+        }
+
+        public void ClearUserIgnoreList()
+        {
+            SetGloballyIgnoredBreachesByUser(null);
         }
     }
 }

--- a/HaveIBeenPwned/BreachCheckers/CloudbleedSite/CloudbleedSiteChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/CloudbleedSite/CloudbleedSiteChecker.cs
@@ -55,7 +55,14 @@ namespace HaveIBeenPwned.BreachCheckers.CloudbleedSite
                         var domainBreaches = breaches.Where(b => url == b && (!oldEntriesOnly || lastModified < new DateTime(2017, 02, 17)));
                         if (domainBreaches.Any())
                         {
-                            breachedEntries.Add(new BreachedEntry(entry, new CloudbleedSiteEntry(string.Empty, entry.GetUrlDomain())));
+                            var item = new BreachedEntry(pluginHost, entry, new CloudbleedSiteEntry(string.Empty, entry.GetUrlDomain()));
+
+                            if (item.IsIgnored)
+                            {
+                                continue;
+                            }
+
+                            breachedEntries.Add(item);
                             if (expireEntries)
                             {
                                 ExpireEntry(entry);

--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedPassword/HaveIBeenPwnedPasswordChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedPassword/HaveIBeenPwnedPasswordChecker.cs
@@ -46,7 +46,14 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedPassword
                 foreach (var breach in breaches)
                 {
                     var pwEntry = breach.Entry;
-                    if(pwEntry != null)
+                    var breachEntry = new BreachedEntry(pluginHost, pwEntry, breach);
+
+                    if (breachEntry.IsIgnored)
+                    {
+                        continue;
+                    }
+
+                    if (pwEntry != null)
                     {
                         if (expireEntries)
                         {
@@ -54,7 +61,7 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedPassword
                         }
                     }
 
-                    breachedEntries.Add(new BreachedEntry(pwEntry, breach));
+                    breachedEntries.Add(breachEntry);
                 }
             });
 
@@ -75,10 +82,11 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedPassword
                 {
                     break;
                 }
-
+                
                 counter++;
                 progressIndicator.Report(new ProgressItem((uint)((double)counter / entries.Count() * 100), string.Format("Checking \"{0}\" for breaches", entry.Strings.ReadSafe(PwDefs.TitleField))));
-                if(entry.Strings.Get(PwDefs.PasswordField) == null || string.IsNullOrWhiteSpace(entry.Strings.ReadSafe(PwDefs.PasswordField)) || entry.Strings.ReadSafe(PwDefs.PasswordField).StartsWith("{REF:")) continue;
+                
+                if (entry.Strings.Get(PwDefs.PasswordField) == null || string.IsNullOrWhiteSpace(entry.Strings.ReadSafe(PwDefs.PasswordField)) || entry.Strings.ReadSafe(PwDefs.PasswordField).StartsWith("{REF:")) continue;
                 var passwordHash = string.Join("", sha.ComputeHash(entry.Strings.Get(PwDefs.PasswordField).ReadUtf8()).Select(x => x.ToString("x2"))).ToUpperInvariant();
                 if (cache.ContainsKey(passwordHash))
                 {
@@ -113,6 +121,7 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedPassword
                     }
                 }
             }
+
             return allBreaches;
         }
     }

--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedPassword/HaveIBeenPwnedPasswordEntry.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedPassword/HaveIBeenPwnedPasswordEntry.cs
@@ -18,7 +18,7 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedPassword
         public string Title {
             get
             {
-                return "HIBP Password Breach";
+                return Resources.PasswordBreachTitle;
             }
         }
 

--- a/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedSite/HaveIBeenPwnedSiteChecker.cs
+++ b/HaveIBeenPwned/BreachCheckers/HaveIBeenPwnedSite/HaveIBeenPwnedSiteChecker.cs
@@ -54,13 +54,22 @@ namespace HaveIBeenPwned.BreachCheckers.HaveIBeenPwnedSite
                     if (!string.IsNullOrEmpty(url))
                     {
                         var domainBreaches = breaches.Where(b => !string.IsNullOrWhiteSpace(b.Domain) && url == b.Domain && (!oldEntriesOnly || lastModified < b.BreachDate)).OrderBy(b => b.BreachDate);
-                        if (domainBreaches.Any())
+
+                        if (!domainBreaches.Any())
                         {
-                            breachedEntries.Add(new BreachedEntry(entry, domainBreaches.Last()));
-                            if (expireEntries)
-                            {
-                                ExpireEntry(entry);
-                            }
+                            continue;
+                        }
+
+                        var breachEntry = new BreachedEntry(pluginHost, entry, domainBreaches.Last());
+
+                        if (!breachEntry.IsIgnored)
+                        {
+                            breachedEntries.Add(breachEntry);
+                        }
+
+                        if (expireEntries)
+                        {
+                            ExpireEntry(entry);
                         }
                     }
                     // this checker is so quick it probably doesn't need to report progress

--- a/HaveIBeenPwned/HaveIBeenPwned.csproj
+++ b/HaveIBeenPwned/HaveIBeenPwned.csproj
@@ -88,6 +88,8 @@
     <Compile Include="BreachCheckers\HaveIBeenPwnedUsername\HaveIBeenPwnedUsernameChecker.cs" />
     <Compile Include="BreachCheckers\HaveIBeenPwnedUsername\HaveIBeenPwnedUsernameEntry.cs" />
     <Compile Include="DisplayAttribute.cs" />
+    <Compile Include="PwDatabaseExtensions.cs" />
+    <Compile Include="StringDictionaryExExtensions.cs" />
     <Compile Include="UI\BreachedEntriesDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/HaveIBeenPwned/PwDatabaseExtensions.cs
+++ b/HaveIBeenPwned/PwDatabaseExtensions.cs
@@ -1,0 +1,31 @@
+﻿using KeePass.Plugins;
+using KeePassLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HaveIBeenPwned
+{
+    public static class PwDatabaseExtensions
+    {
+        public static void MarkAsModified(this IPluginHost pluginHost)
+        {
+            // Make a nothing change to try to trigger the '*' to notify the user of a change.
+
+            // TODO: This doesn't seem to work properly. Need to figure out why and fix it.
+
+            var database = pluginHost.Database;
+
+            // And This doesn't seem to work
+            database.Modified = true;
+
+            var notes = database.RootGroup.Notes;
+            database.RootGroup.Notes = notes + ".";
+            database.RootGroup.Notes = notes;
+            
+            pluginHost.MainWindow.Refresh();
+        }
+    }
+}

--- a/HaveIBeenPwned/Resources.Designer.cs
+++ b/HaveIBeenPwned/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace HaveIBeenPwned {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -71,6 +71,15 @@ namespace HaveIBeenPwned {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HaveIBeenPwned:IgnoreBreachs.
+        /// </summary>
+        internal static string FieldNameIgnoredBreachs {
+            get {
+                return ResourceManager.GetString("FieldNameIgnoredBreachs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
         /// </summary>
         internal static System.Drawing.Icon hibp {
@@ -86,6 +95,15 @@ namespace HaveIBeenPwned {
         internal static string MenuItemCheckAllTitle {
             get {
                 return ResourceManager.GetString("MenuItemCheckAllTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear all ignore lists.
+        /// </summary>
+        internal static string MenuItemClearIgnoreListTitle {
+            get {
+                return ResourceManager.GetString("MenuItemClearIgnoreListTitle", resourceCulture);
             }
         }
         
@@ -131,6 +149,15 @@ namespace HaveIBeenPwned {
         internal static string MessageTitle {
             get {
                 return ResourceManager.GetString("MessageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HIBP Password Breach.
+        /// </summary>
+        internal static string PasswordBreachTitle {
+            get {
+                return ResourceManager.GetString("PasswordBreachTitle", resourceCulture);
             }
         }
     }

--- a/HaveIBeenPwned/Resources.resx
+++ b/HaveIBeenPwned/Resources.resx
@@ -2126,4 +2126,13 @@
   <data name="MenuTitle" xml:space="preserve">
     <value>Have I Been Pwned?</value>
   </data>
+  <data name="FieldNameIgnoredBreachs" xml:space="preserve">
+    <value>HaveIBeenPwned:IgnoreBreachs</value>
+  </data>
+  <data name="PasswordBreachTitle" xml:space="preserve">
+    <value>HIBP Password Breach</value>
+  </data>
+  <data name="MenuItemClearIgnoreListTitle" xml:space="preserve">
+    <value>Clear all ignore lists</value>
+  </data>
 </root>

--- a/HaveIBeenPwned/StringDictionaryExExtensions.cs
+++ b/HaveIBeenPwned/StringDictionaryExExtensions.cs
@@ -1,0 +1,50 @@
+﻿using KeePassLib.Collections;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HaveIBeenPwned
+{
+    public static class StringDictionaryExExtensions
+    {
+        public static bool Set<T>(this StringDictionaryEx dict, string fieldName, T value)
+        {
+            var isDefault = EqualityComparer<T>.Default.Equals(default(T), value);
+            if (isDefault)
+            {
+                if (!dict.Any(x => x.Key == fieldName))
+                {
+                    return false;
+                }
+
+                dict.Remove(fieldName);
+                return true;
+            }
+
+            var oldValue = dict.Get(fieldName);
+            var newValue = JsonConvert.SerializeObject(value);
+
+            if (oldValue == newValue)
+            {
+                return false;
+            }
+
+            dict.Set(fieldName, newValue);
+            return true;
+        }
+
+        public static T Get<T>(this StringDictionaryEx dict, string fieldName)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(dict.Get(fieldName));
+            }
+            catch (Exception) {
+                return default(T);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi,

This is my solution to issues/72 and linked issues.

It's basically:
- Provide a right click interface on the BreachedEntriedDialog to allow the user to ignore individual breaches as they apply to each entry, or individual breaches as they apply breached usernames
- Store this informtion in the entry's plugin data
- Extend BreachEntry to be aware of whether a breach should be ignored or not.
- Have the checkers check whether a BreachEntry should be ignored prior to adding it to the final breach list.

Amongst all this I 
* Added generic extension methods in StringDictionryExExtension to store arbitary data (JSON serializable) data within the entry's plugin data. This could possibly be pushed upstream to keepass2-developerextensions.
* Added an extension method to PwDatabaseExtensions to make the database as modified (see below)

Note that the 'MarkAsModified' methods doesn't seem to work properly yet. It does make changes in the database and marks the database as modified, but the '*' doesn't appear at the top of the keepass window. If you close KeePass without saving, your changed perferences are lossed. If however you open an entry dialogue and press cancel.. the '*' appears properly. I haven't got to the bottom of this yet and won't be in a position to investigate further for the next month. I wanted to send this lot to you now in case you are interested.

Possible future enhancements
* Utilise the entry properties to store the users other 'ignore' preference, like 'only check entities that have not changes since the breach', 'ignore any deleted entries', ignore expired entries' and 'expire entries that are found to be breached'
* Instead of ignoring items within the Checker,. have the checkers return all items, allow the user to modify their preferences within the breach dialog and update the dialog appropritely.